### PR TITLE
refactor: coap request params up the call tree

### DIFF
--- a/client.js
+++ b/client.js
@@ -4,5 +4,16 @@
     'use strict';
     
     var CoapClient = require('./CoapClient');
-    CoapClient.command();
+
+    var requestParameters = {
+        method: 'put',
+        confirmable: true,
+        hostName: '10.1.1.38',
+        pathName: 'leds'
+    };
+    var requestPayload = {
+
+    };
+
+    CoapClient.command(requestParameters, requestPayload);
 })();


### PR DESCRIPTION
Currently the coap request parameters are hard coded on the coap
libraries Coap.js and Coapclient.js. The parameters should come from
higher levers in the call tree.

Also, the knowledge of what kind of coap payload the ELL-i light
fixtures want should be in another library specific for them.

Suspected file changes:
client.js
Coap.js
Coapclient.js
ELL-i-fixture.js
